### PR TITLE
Make WIFI_CONFIG.py self-documenting

### DIFF
--- a/badger_os/WIFI_CONFIG.py
+++ b/badger_os/WIFI_CONFIG.py
@@ -1,3 +1,3 @@
-SSID = ""
-PSK = ""
-COUNTRY = ""
+SSID = "YOUR_WIFI_SSID"
+PSK = "YOUR_WIFI_PASSWORD"
+COUNTRY = "YOUR_COUNTRY_CODE"  # Change to your local two-letter ISO 3166-1 country code


### PR DESCRIPTION
The version currently in the repo doesn't include the sample text that other Pimoroni repos have so its hard for a beginner to know what to put in this file.